### PR TITLE
Fix critical bug: usedTitles Set never populated

### DIFF
--- a/src/notes-manager.ts
+++ b/src/notes-manager.ts
@@ -46,6 +46,7 @@ export class NotesManager {
 			title = `${baseTitle} ${counter}`;
 			counter++;
 		}
+		this.usedTitles.add(title);
 		return normalizePath(title);
 	}
 }


### PR DESCRIPTION
The getUniqueTitle() method was checking for duplicate titles but never adding titles to the usedTitles Set, making duplicate prevention completely ineffective. This caused file creation failures when OpenAI generated multiple notes with identical titles.

Fix: Add title to usedTitles Set after generating unique name.

Fixes critical issue C1 from CODE_REVIEW.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)