### PR TITLE
Handle notes with missing titles instead of silent failure

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -116,9 +116,18 @@ export default class AtomizerPlugin extends Plugin {
 					await notesManager.saveNote(note);
 				}
 
-				new Notice(
-					`Successfully created ${atomicNotes.length} atomic notes`,
-				);
+				// Check if any notes were missing titles
+				const skippedNotes = notesManager.getSkippedNotes();
+				if (skippedNotes.length > 0) {
+					new Notice(
+						`Successfully created ${atomicNotes.length} atomic notes. Warning: ${skippedNotes.length} note(s) were missing titles and given fallback names.`,
+						8000,
+					);
+				} else {
+					new Notice(
+						`Successfully created ${atomicNotes.length} atomic notes`,
+					);
+				}
 			} catch (error) {
 				this.handleError(error);
 			} finally {

--- a/src/notes-manager.ts
+++ b/src/notes-manager.ts
@@ -5,6 +5,8 @@ import { App, normalizePath } from "obsidian";
  */
 export class NotesManager {
 	private usedTitles = new Set<string>();
+	private untitledCounter = 1;
+	private skippedNotes: string[] = [];
 
 	constructor(
 		private app: App,
@@ -25,15 +27,31 @@ export class NotesManager {
 	 */
 	async saveNote(note: string): Promise<void> {
 		const titleMatch = note.match(/^#\s+(.+)$/m);
+		let baseTitle: string;
+
 		if (!titleMatch || !titleMatch[1]) {
-			console.warn("No title found in note:", note.slice(0, 100));
-			return;
+			// Generate fallback title for notes without titles
+			baseTitle = `Untitled Note ${this.untitledCounter}`;
+			this.untitledCounter++;
+			console.warn("No title found in note, using fallback:", baseTitle);
+			this.skippedNotes.push(baseTitle);
+
+			// Prepend a title to the note content
+			note = `# ${baseTitle}\n\n${note}`;
+		} else {
+			baseTitle = titleMatch[1].trim();
 		}
 
-		const baseTitle = titleMatch[1].trim();
 		const title = this.getUniqueTitle(baseTitle);
 		const fileName = `${this.folderPath}/${normalizePath(title)}.md`;
 		await this.app.vault.create(fileName, note.trim());
+	}
+
+	/**
+	 * Get list of notes that were missing titles
+	 */
+	getSkippedNotes(): string[] {
+		return this.skippedNotes;
 	}
 
 	/**
@@ -46,6 +64,7 @@ export class NotesManager {
 			title = `${baseTitle} ${counter}`;
 			counter++;
 		}
+		this.usedTitles.add(title);
 		return normalizePath(title);
 	}
 }


### PR DESCRIPTION
Replace silent failure when notes lack titles with automatic fallback title generation and user notification:

NotesManager changes:
- Track notes that needed fallback titles
- Generate sequential fallback titles: "Untitled Note 1", "Untitled Note 2"
- Prepend generated title to note content (maintains proper formatting)
- Provide getSkippedNotes() method to report issues

Main.ts changes:
- Check for notes with missing titles after processing
- Show warning notice when fallback titles were used
- Longer notice duration (8s) to ensure user sees the warning
- Accurate count: users know exactly how many notes and how many issues

Benefits:
- No data loss (all notes are saved, not silently dropped)
- User is informed about formatting issues
- Generated notes are still usable with descriptive fallback names
- Console warnings remain for debugging

Fixes H7 (Silent failure on missing title) from CODE_REVIEW.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)